### PR TITLE
TECH-150: use content when available, don't override yml files

### DIFF
--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
@@ -226,7 +226,7 @@ public class ConfigurationSupport extends CellarSupport {
             if (storageFile == null && cfg.getProperties().get(ConfigurationAdmin.SERVICE_FACTORYPID) != null) {
                 storageFile = new File(storage, cfg.getPid() + ".cfg");
             }
-            if (storageFile == null) {
+            if (storageFile == null || (!storageFile.getName().endsWith(".cfg") && !storageFile.getName().endsWith(".config"))) {
                 // it's a factory configuration without filename specified, cannot save
                 return;
             }

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -139,8 +139,8 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                             localDictionary = filter(localDictionary);
                             if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary) && shouldReplicateConfig(clusterDictionary)) {
                                 LOGGER.debug("CELLAR CONFIG: updating configration {} on node", pid);
-                                clusterDictionary = convertPropertiesFromCluster(clusterDictionary);
-                                localConfiguration.update((Dictionary) clusterDictionary);
+                                Dictionary convertedDictionary = convertPropertiesFromCluster(clusterDictionary);
+                                localConfiguration.update(convertedDictionary);
                                 persistConfiguration(localConfiguration, clusterDictionary);
                             }
                         } catch (IOException ex) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-150

## Description

- Use file content stored in hazelcast on initial sync 
- Skip properties serialization when file is not a cfg