### PR TITLE
BACKLOG-20840: Do not save file based on properties, always rely on content

### DIFF
--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -76,6 +76,8 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
         if (isAllowed(event.getSourceGroup(), Constants.CATEGORY, pid, EventType.INBOUND)) {
             synchronized (clusterConfigurations) {
                 Dictionary clusterDictionary = clusterConfigurations.get(pid);
+                LOGGER.debug("Received event for configuration {} , cluster data : {}", pid, clusterDictionary);
+
                 try {
                     // update the local configuration
                     Configuration localConfiguration = findLocalConfiguration(pid, clusterDictionary);
@@ -104,6 +106,7 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                                 Dictionary convertedDictionary = convertPropertiesFromCluster(clusterDictionary);
                                 if (!localConfiguration.getPid().equals(pid)) {
                                     Properties p = dictionaryToProperties(filter(convertedDictionary));
+                                    LOGGER.debug("Storing factory configuration local pid: {}, from {} : {}", localConfiguration.getProperties(), pid, localDictionary);
                                     clusterConfigurations.put(localConfiguration.getPid(), p);
                                 }
                                 localConfiguration.update(convertedDictionary);

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -25,6 +25,7 @@ import org.osgi.service.cm.ConfigurationEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Map;
 import java.util.Properties;
@@ -76,7 +77,7 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
         if (isAllowed(event.getSourceGroup(), Constants.CATEGORY, pid, EventType.INBOUND)) {
             synchronized (clusterConfigurations) {
                 Dictionary clusterDictionary = clusterConfigurations.get(pid);
-                LOGGER.debug("Received event for configuration {} , cluster data : {}", pid, clusterDictionary);
+                LOGGER.debug("Received event for configuration {} , cluster data : {}", pid, Collections.list(clusterDictionary.keys()));
 
                 try {
                     // update the local configuration
@@ -106,7 +107,7 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                                 Dictionary convertedDictionary = convertPropertiesFromCluster(clusterDictionary);
                                 if (!localConfiguration.getPid().equals(pid)) {
                                     Properties p = dictionaryToProperties(filter(convertedDictionary));
-                                    LOGGER.debug("Storing factory configuration local pid: {}, from {} : {}", localConfiguration.getProperties(), pid, localDictionary);
+                                    LOGGER.debug("Storing factory configuration local pid: {}, from {} : {}", localConfiguration.getProperties(), pid, Collections.list(localDictionary.keys()));
                                     clusterConfigurations.put(localConfiguration.getPid(), p);
                                 }
                                 localConfiguration.update(convertedDictionary);

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
@@ -124,6 +124,7 @@ public class ConfigurationSupport extends CellarSupport {
                     try {
                         result.put(KARAF_CELLAR_CONTENT, readFile(new File(storage, value)));
                     } catch (IOException e) {
+                        LOGGER.debug("Cannot read file content for {}", value);
                         // Cannot read file
                     }
                 } else if (!isExcludedProperty(key)) {

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
@@ -250,41 +250,11 @@ public class ConfigurationSupport extends CellarSupport {
             }
 
             String content = clusterDictionary == null ? null : (String) clusterDictionary.get(KARAF_CELLAR_CONTENT);
-
-            if (content == null && isCfg) {
-                LOGGER.debug("Persisting file base on properties, has content was null in KARAF_CELLAR_CONTENT");
-                org.apache.felix.utils.properties.Properties p = new org.apache.felix.utils.properties.Properties(storageFile);
-                List<String> propertiesToRemove = new ArrayList<String>();
-                Set<String> set = p.keySet();
-
-                for (String key : set) {
-                    if (!org.osgi.framework.Constants.SERVICE_PID.equals(key)
-                            && !ConfigurationAdmin.SERVICE_FACTORYPID.equals(key)
-                            && !KARAF_CELLAR_FILENAME.equals(key)
-                            && !FELIX_FILEINSTALL_FILENAME.equals(key)) {
-                        propertiesToRemove.add(key);
-                    }
-                }
-
-                for (String key : propertiesToRemove) {
-                    p.remove(key);
-                }
-                for (Enumeration<String> keys = localDictionary.keys(); keys.hasMoreElements(); ) {
-                    String key = keys.nextElement();
-                    if (!org.osgi.framework.Constants.SERVICE_PID.equals(key)
-                            && !ConfigurationAdmin.SERVICE_FACTORYPID.equals(key)
-                            && !KARAF_CELLAR_FILENAME.equals(key)
-                            && !FELIX_FILEINSTALL_FILENAME.equals(key)) {
-                        p.put(key, (String) localDictionary.get(key));
-                    }
-                }
-
-                // save the cfg file
-                storage.mkdirs();
-                p.save();
-            } else if (content != null) {
+            if (content != null) {
                 LOGGER.debug("Persisting file base on KARAF_CELLAR_CONTENT");
                 writeFile(storageFile, content);
+            } else {
+                LOGGER.debug("File content is null, don't save file now. Dictionary : {}", clusterDictionary);
             }
         } catch (Exception e) {
             LOGGER.error("CELLAR CONFIG: Issue when trying to persist configuration file", e);

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -211,7 +211,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                     Dictionary localDictionary = localConfiguration.getProperties();
                                     localDictionary = filter(localDictionary);
                                     if (!clusterConfigurations.containsKey(pid)) {
-                                        LOGGER.debug("CELLAR CONFIG: creating configuration pid {} on the cluster: {}", pid, localDictionary);
+                                        LOGGER.debug("CELLAR CONFIG: creating configuration pid {} on the cluster: {}", pid, Collections.list(localDictionary.keys()));
                                         // update cluster configurations
                                         clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
                                         // send cluster event

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -211,7 +211,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                     Dictionary localDictionary = localConfiguration.getProperties();
                                     localDictionary = filter(localDictionary);
                                     if (!clusterConfigurations.containsKey(pid)) {
-                                        LOGGER.debug("CELLAR CONFIG: creating configuration pid {} on the cluster", pid);
+                                        LOGGER.debug("CELLAR CONFIG: creating configuration pid {} on the cluster: {}", pid, localDictionary);
                                         // update cluster configurations
                                         clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
                                         // send cluster event

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -211,7 +211,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                     Dictionary localDictionary = localConfiguration.getProperties();
                                     localDictionary = filter(localDictionary);
                                     if (!clusterConfigurations.containsKey(pid)) {
-                                        LOGGER.debug("CELLAR CONFIG: creating configuration pid {} on the cluster", pid);
+                                        LOGGER.debug("CELLAR CONFIG: creating configuration pid {} on the cluster", pid);
                                         // update cluster configurations
                                         clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
                                         // send cluster event

--- a/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
@@ -101,6 +101,7 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
 
                                 if (!equals(localDictionary, distributedDictionary) && canDistributeConfig(localDictionary)) {
                                     // update the configurations in the cluster group
+                                    LOGGER.debug("Storing configuration {} in cluster {}", pid, localDictionary);
                                     clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
                                     // send the cluster event
                                     ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);

--- a/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
@@ -101,7 +101,7 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
 
                                 if (!equals(localDictionary, distributedDictionary) && canDistributeConfig(localDictionary)) {
                                     // update the configurations in the cluster group
-                                    LOGGER.debug("Storing configuration {} in cluster {}", pid, localDictionary);
+                                    LOGGER.debug("Storing configuration {} in cluster {}", pid, Collections.list(localDictionary.keys()));
                                     clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
                                     // send the cluster event
                                     ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20840

## Description

Case without KARAF_CELLAR_CONTENT should not happen , and it's better to not save any file at all than regenerating a different file
