### PR TITLE
TECH-1942:  Propose a fix for the config replication in cluster issue in Apache Karaf Cellar (fix also TECH-1962)

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -110,6 +110,14 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -110,14 +110,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/config/src/main/java/org/apache/karaf/cellar/config/ClusterConfigurationEvent.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ClusterConfigurationEvent.java
@@ -23,7 +23,7 @@ public class ClusterConfigurationEvent extends Event {
 
 	private Integer type;
     private Node local;
-    private String oid;
+    private String integrity;
 
     public ClusterConfigurationEvent(String id) {
         super(id);
@@ -45,12 +45,12 @@ public class ClusterConfigurationEvent extends Event {
         this.local = local;
     }
 
-    public String getOid() {
-        return oid;
+    public String getIntegrity() {
+        return integrity;
     }
 
-    public void setOid(String oid) {
-        this.oid = oid;
+    public void setIntegrity(String integrity) {
+        this.integrity = integrity;
     }
 
     @Override
@@ -58,7 +58,7 @@ public class ClusterConfigurationEvent extends Event {
 		return "ClusterConfigurationEvent [type=" + type + ", id=" + id
 				+ ", sourceNode=" + sourceNode + ", sourceGroup=" + sourceGroup
 				+ ", destination=" + destination + ", force=" + force
-				+ ", postPublish=" + postPublish + ", oid=" + oid
+				+ ", postPublish=" + postPublish + ", integrity=" + integrity
                 + "]";
 	}
 

--- a/config/src/main/java/org/apache/karaf/cellar/config/ClusterConfigurationEvent.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ClusterConfigurationEvent.java
@@ -23,6 +23,7 @@ public class ClusterConfigurationEvent extends Event {
 
 	private Integer type;
     private Node local;
+    private String oid;
 
     public ClusterConfigurationEvent(String id) {
         super(id);
@@ -44,12 +45,21 @@ public class ClusterConfigurationEvent extends Event {
         this.local = local;
     }
 
+    public String getOid() {
+        return oid;
+    }
+
+    public void setOid(String oid) {
+        this.oid = oid;
+    }
+
     @Override
 	public String toString() {
 		return "ClusterConfigurationEvent [type=" + type + ", id=" + id
 				+ ", sourceNode=" + sourceNode + ", sourceGroup=" + sourceGroup
 				+ ", destination=" + destination + ", force=" + force
-				+ ", postPublish=" + postPublish + "]";
+				+ ", postPublish=" + postPublish + ", oid=" + oid
+                + "]";
 	}
 
 }

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -41,6 +41,8 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
 
     private final Switch eventSwitch = new BasicSwitch(SWITCH_ID);
 
+    private static final Object monitor = new Object();
+
     @Override
     public void handle(ClusterConfigurationEvent event) {
         // check if the handler is ON
@@ -69,34 +71,33 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
 
         Group group = event.getSourceGroup();
         String groupName = group.getName();
-
-        Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
-
         String pid = event.getId();
 
         if (isAllowed(event.getSourceGroup(), Constants.CATEGORY, pid, EventType.INBOUND)) {
-            synchronized (clusterConfigurations) {
-                int tries = 3;
+            synchronized (monitor) {
+                int tries = 5;
                 boolean configSync = false;
+                Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
                 Dictionary clusterDictionary = clusterConfigurations.get(pid);
                 LOGGER.debug("Received event for configuration {} , cluster data : {}", pid, Collections.list(clusterDictionary.keys()));
                 while (!configSync && tries > 0) {
-                    if (event.getOid() != null && !event.getOid().equals(clusterDictionary.get(KARAF_CELLAR_OID))) {
-                        LOGGER.info("CELLAR CONFIG: event oid {} is not in sync with the cluster configuration oid {}, waiting for hazelcast map sync and retry...",
-                                event.getOid(), clusterDictionary.get(KARAF_CELLAR_OID));
+                    if (event.getIntegrity() != null && !event.getIntegrity().equals(hash((Properties)clusterDictionary))) {
+                        LOGGER.info("CELLAR CONFIG: event integrity {} is not in sync with the cluster configuration, "
+                                + "waiting for hazelcast map sync and retry...", event.getIntegrity());
                         tries--;
                         try {
-                            Thread.sleep(1000);
+                            Thread.sleep(100);
                         } catch (InterruptedException ignored) {
                         }
+                        clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
                         clusterDictionary = clusterConfigurations.get(pid);
                     } else {
                         configSync = true;
                     }
                 }
                 if (!configSync) {
-                    LOGGER.error("CELLAR CONFIG: event oid {} is not in sync with the cluster configuration, this will let that node configuration inconsistent, giving up retry. Perform a manual configuration consistency check after that !!", event);
-                    return;
+                    LOGGER.error("CELLAR CONFIG: event {} is not in sync with the cluster configuration, this may let that node configuration "
+                            + "inconsistent, giving up retry. Perform a manual configuration consistency check after that !!", event);
                 }
                 try {
                     // update the local configuration

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -76,12 +76,32 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
 
         if (isAllowed(event.getSourceGroup(), Constants.CATEGORY, pid, EventType.INBOUND)) {
             synchronized (clusterConfigurations) {
+                int tries = 3;
+                boolean configSync = false;
                 Dictionary clusterDictionary = clusterConfigurations.get(pid);
                 LOGGER.debug("Received event for configuration {} , cluster data : {}", pid, Collections.list(clusterDictionary.keys()));
-
+                while (!configSync && tries > 0) {
+                    if (event.getOid() != null && !event.getOid().equals(clusterDictionary.get(KARAF_CELLAR_OID))) {
+                        LOGGER.warn("CELLAR CONFIG: event {} is not in sync with the cluster configuration, waiting sync and retry...",
+                                event);
+                        tries--;
+                        try {
+                            this.wait(1000);
+                        } catch (InterruptedException ignored) {
+                        }
+                        clusterDictionary = clusterConfigurations.get(pid);
+                    } else {
+                        configSync = true;
+                    }
+                }
+                if (!configSync) {
+                    LOGGER.error("CELLAR CONFIG: event {} is not in sync with the cluster configuration, giving up...", event);
+                    return;
+                }
                 try {
                     // update the local configuration
                     Configuration localConfiguration = findLocalConfiguration(pid, clusterDictionary);
+
                     if (event.getType() != null && event.getType() == ConfigurationEvent.CM_DELETED) {
                         // delete the configuration
                         if (localConfiguration != null) {

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -82,7 +82,7 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                 LOGGER.debug("Received event for configuration {} , cluster data : {}", pid, Collections.list(clusterDictionary.keys()));
                 while (!configSync && tries > 0) {
                     if (event.getOid() != null && !event.getOid().equals(clusterDictionary.get(KARAF_CELLAR_OID))) {
-                        LOGGER.warn("CELLAR CONFIG: event oid {} is not in sync with the cluster configuration oid {}, waiting sync and retry...",
+                        LOGGER.info("CELLAR CONFIG: event oid {} is not in sync with the cluster configuration oid {}, waiting for hazelcast map sync and retry...",
                                 event.getOid(), clusterDictionary.get(KARAF_CELLAR_OID));
                         tries--;
                         try {
@@ -95,7 +95,7 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                     }
                 }
                 if (!configSync) {
-                    LOGGER.error("CELLAR CONFIG: event {} is not in sync with the cluster configuration, giving up...", event);
+                    LOGGER.error("CELLAR CONFIG: event oid {} is not in sync with the cluster configuration, this will let that node configuration inconsistent, giving up retry. Perform a manual configuration consistency check after that !!", event);
                     return;
                 }
                 try {

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -38,6 +38,10 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
     private static final transient Logger LOGGER = LoggerFactory.getLogger(ConfigurationEventHandler.class);
 
     public static final String SWITCH_ID = "org.apache.karaf.cellar.configuration.handler";
+    public static final int INTEGRITY_TRY_COUNT_DEFAULT = 5;
+    public static final String INTEGRITY_TRY_COUNT_PROP = "config.integrityCheck.retryCount";
+    public static final int INTEGRITY_TRY_INTERVAL_DEFAULT = 100;
+    public static final String INTEGRITY_TRY_INTERVAL_PROP = "config.integrityCheck.retryIntervalMS";
 
     private final Switch eventSwitch = new BasicSwitch(SWITCH_ID);
 
@@ -75,30 +79,46 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
 
         if (isAllowed(event.getSourceGroup(), Constants.CATEGORY, pid, EventType.INBOUND)) {
             synchronized (monitor) {
-                int tries = 5;
-                boolean configSync = false;
                 Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
                 Dictionary clusterDictionary = clusterConfigurations.get(pid);
-                LOGGER.debug("Received event for configuration {} , cluster data : {}", pid, Collections.list(clusterDictionary.keys()));
-                while (!configSync && tries > 0) {
-                    if (event.getIntegrity() != null && !event.getIntegrity().equals(hash((Properties)clusterDictionary))) {
-                        LOGGER.debug("CELLAR CONFIG: event integrity {} is not sync with the cluster configuration, "
-                                + "waiting 100ms for hazelcast map sync and retry...", event.getIntegrity());
-                        tries--;
+                LOGGER.debug("CELLAR CONFIG: Received event for configuration {}, cluster data : {}", pid, Collections.list(clusterDictionary.keys()));
+
+                // Integrity check and retry if needed
+                boolean clusterConfigIntegrityCheck = integrityCheck(event.getIntegrity(), clusterDictionary);
+                if (!clusterConfigIntegrityCheck) {
+                    int tries = getIntegrityTryCount();
+                    int interval = getIntegrityTryInterval();
+
+                    LOGGER.warn("CELLAR CONFIG: Integrity check failed between received config update event and cluster configuration for pid: {}, " +
+                            "will retry {} times with {}ms interval", pid, tries, interval);
+                    while (!clusterConfigIntegrityCheck && tries > 0) {
+                        // Wait for a while before retrying
                         try {
-                            Thread.sleep(100);
+                            Thread.sleep(interval);
                         } catch (InterruptedException ignored) {
                         }
+
+                        // Reload cluster configuration
                         clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
                         clusterDictionary = clusterConfigurations.get(pid);
-                    } else {
-                        configSync = true;
+
+                        // Check integrity again
+                        if (!integrityCheck(event.getIntegrity(), clusterDictionary)) {
+                            tries--;
+                            if (tries > 0) {
+                                LOGGER.warn("CELLAR CONFIG: Integrity check still incorrect for pid: {}, " +
+                                        "will retry in {}ms, remaining tries: {}", pid, interval, tries);
+                            } else {
+                                LOGGER.error("CELLAR CONFIG: Integrity check still incorrect for pid: {}, giving up after retries limit reached, " +
+                                        "this may let that node configuration inconsistent. It's recommended to perform a manual cluster configuration sync !", pid);
+                            }
+                        } else {
+                            clusterConfigIntegrityCheck = true;
+                            LOGGER.info("CELLAR CONFIG: Integrity check success for pid: {} after retries", pid);
+                        }
                     }
                 }
-                if (!configSync) {
-                    LOGGER.error("CELLAR CONFIG: event {} is not sync with the cluster configuration, this may let that node configuration "
-                            + "inconsistent, giving up after 10 retries. Perform a manual configuration consistency check after that !!", event);
-                }
+
                 try {
                     // update the local configuration
                     Configuration localConfiguration = findLocalConfiguration(pid, clusterDictionary);
@@ -106,7 +126,7 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                     if (event.getType() != null && event.getType() == ConfigurationEvent.CM_DELETED) {
                         // delete the configuration
                         if (localConfiguration != null) {
-                            LOGGER.debug("Local config found, deleting it - pid = {}, from {}", localConfiguration.getPid(), pid);
+                            LOGGER.debug("CELLAR CONFIG: Local config found, deleting it - pid = {}, from {}", localConfiguration.getPid(), pid);
                             deleteConfiguration(localConfiguration);
                         }
                     } else {
@@ -114,9 +134,9 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                             if (localConfiguration == null) {
                                 // Create new configuration
                                 localConfiguration = createLocalConfiguration(pid, clusterDictionary);
-                                LOGGER.debug("Local config created - local pid: {}, from {} ", localConfiguration.getPid(), pid);
+                                LOGGER.debug("CELLAR CONFIG: Local config created - local pid: {}, from {} ", localConfiguration.getPid(), pid);
                             } else {
-                                LOGGER.debug("Local config found, updating - pid = {}, from {}", localConfiguration.getPid(), pid);
+                                LOGGER.debug("CELLAR CONFIG: Local config found, updating - pid = {}, from {}", localConfiguration.getPid(), pid);
                             }
                             Dictionary localDictionary = localConfiguration.getProperties();
                             if (localDictionary == null) {
@@ -128,7 +148,7 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                                 Dictionary convertedDictionary = convertPropertiesFromCluster(clusterDictionary);
                                 if (!localConfiguration.getPid().equals(pid)) {
                                     Properties p = dictionaryToProperties(filter(convertedDictionary));
-                                    LOGGER.debug("Storing factory configuration local pid: {}, from {} : {}", localConfiguration.getProperties(), pid, Collections.list(localDictionary.keys()));
+                                    LOGGER.debug("CELLAR CONFIG: Storing factory configuration local pid: {}, from {} : {}", localConfiguration.getProperties(), pid, Collections.list(localDictionary.keys()));
                                     clusterConfigurations.put(localConfiguration.getPid(), p);
                                 }
                                 localConfiguration.update(convertedDictionary);
@@ -148,6 +168,42 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
 
     public void destroy() {
         // nothing to do
+    }
+
+    private boolean integrityCheck(String integrityHash, Dictionary dictionary) {
+        // In case of deleted conf event, integrityHash is null, we consider it as correct
+        return integrityHash == null ||
+                (dictionary != null && integrityHash.equals(hash((Properties) dictionary)));
+    }
+
+    private int getIntegrityTryCount() {
+        try {
+            Configuration configuration = configurationAdmin.getConfiguration(Configurations.NODE, null);
+            if (configuration != null) {
+                String value = (String) configuration.getProperties().get(INTEGRITY_TRY_COUNT_PROP);
+                if (value != null) {
+                    return Integer.parseInt(value);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("CELLAR CONFIG: can't get integrity try count", e);
+        }
+        return INTEGRITY_TRY_COUNT_DEFAULT;
+    }
+
+    private int getIntegrityTryInterval() {
+        try {
+            Configuration configuration = configurationAdmin.getConfiguration(Configurations.NODE, null);
+            if (configuration != null) {
+                String value = (String) configuration.getProperties().get(INTEGRITY_TRY_INTERVAL_PROP);
+                if (value != null) {
+                    return Integer.parseInt(value);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("CELLAR CONFIG: can't get integrity try interval", e);
+        }
+        return INTEGRITY_TRY_INTERVAL_DEFAULT;
     }
 
     /**

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -82,8 +82,8 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                 LOGGER.debug("Received event for configuration {} , cluster data : {}", pid, Collections.list(clusterDictionary.keys()));
                 while (!configSync && tries > 0) {
                     if (event.getIntegrity() != null && !event.getIntegrity().equals(hash((Properties)clusterDictionary))) {
-                        LOGGER.info("CELLAR CONFIG: event integrity {} is not in sync with the cluster configuration, "
-                                + "waiting for hazelcast map sync and retry...", event.getIntegrity());
+                        LOGGER.debug("CELLAR CONFIG: event integrity {} is not sync with the cluster configuration, "
+                                + "waiting 100ms for hazelcast map sync and retry...", event.getIntegrity());
                         tries--;
                         try {
                             Thread.sleep(100);
@@ -96,8 +96,8 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                     }
                 }
                 if (!configSync) {
-                    LOGGER.error("CELLAR CONFIG: event {} is not in sync with the cluster configuration, this may let that node configuration "
-                            + "inconsistent, giving up retry. Perform a manual configuration consistency check after that !!", event);
+                    LOGGER.error("CELLAR CONFIG: event {} is not sync with the cluster configuration, this may let that node configuration "
+                            + "inconsistent, giving up after 10 retries. Perform a manual configuration consistency check after that !!", event);
                 }
                 try {
                     // update the local configuration

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -82,11 +82,11 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                 LOGGER.debug("Received event for configuration {} , cluster data : {}", pid, Collections.list(clusterDictionary.keys()));
                 while (!configSync && tries > 0) {
                     if (event.getOid() != null && !event.getOid().equals(clusterDictionary.get(KARAF_CELLAR_OID))) {
-                        LOGGER.warn("CELLAR CONFIG: event {} is not in sync with the cluster configuration, waiting sync and retry...",
-                                event);
+                        LOGGER.warn("CELLAR CONFIG: event oid {} is not in sync with the cluster configuration oid {}, waiting sync and retry...",
+                                event.getOid(), clusterDictionary.get(KARAF_CELLAR_OID));
                         tries--;
                         try {
-                            this.wait(1000);
+                            Thread.sleep(1000);
                         } catch (InterruptedException ignored) {
                         }
                         clusterDictionary = clusterConfigurations.get(pid);

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
@@ -33,6 +33,7 @@ public class ConfigurationSupport extends CellarSupport {
     public static final String KARAF_CELLAR_FILENAME = "karaf.cellar.filename";
     public static final String KARAF_CELLAR_CONTENT = "karaf.cellar.content";
     public static final String KARAF_CELLAR_REMOVED = "karaf.cellar.removed";
+    public static final String KARAF_CELLAR_OID = "karaf.cellar.oid";
 
     protected File storage;
 

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
@@ -22,6 +22,8 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import java.io.*;
 import java.net.URI;
 import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 /**
@@ -33,7 +35,6 @@ public class ConfigurationSupport extends CellarSupport {
     public static final String KARAF_CELLAR_FILENAME = "karaf.cellar.filename";
     public static final String KARAF_CELLAR_CONTENT = "karaf.cellar.content";
     public static final String KARAF_CELLAR_REMOVED = "karaf.cellar.removed";
-    public static final String KARAF_CELLAR_OID = "karaf.cellar.oid";
 
     protected File storage;
 
@@ -55,6 +56,28 @@ public class ConfigurationSupport extends CellarSupport {
             }
         }
         return properties;
+    }
+
+    /**
+     * Read a {@code Properties} and generate a hash of its keys and values.
+     *
+     * @param properties the source properties.
+     * @return the generated hashcode.
+     */
+    public static String hash(Properties properties) {
+        try {
+            MessageDigest hash = MessageDigest.getInstance("SHA-1");
+            hash.reset();
+            List<String> keys = new ArrayList(properties.stringPropertyNames());
+            Collections.sort(keys);
+            for (String key : keys) {
+                hash.update(key.getBytes("UTF-8"));
+                hash.update(properties.getProperty(key).getBytes("UTF-8"));
+            }
+            return Base64.getEncoder().encodeToString(hash.digest());
+        } catch(NoSuchAlgorithmException | UnsupportedEncodingException e) {
+            return "error";
+        }
     }
 
     /**

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -200,59 +200,66 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
             try {
                 Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
                 Configuration[] localConfigurations;
-                    try {
-                        localConfigurations = configurationAdmin.listConfigurations(null);
-                        // push local configurations to the cluster
-                        for (Configuration localConfiguration : localConfigurations) {
-                            String pid = localConfiguration.getPid();
-                            // check if the pid is marked as local.
-                            if (isAllowed(group, Constants.CATEGORY, pid, EventType.OUTBOUND)) {
-                                synchronized (clusterConfigurations) {
-                                    Dictionary localDictionary = localConfiguration.getProperties();
-                                    localDictionary = filter(localDictionary);
-                                    if (!clusterConfigurations.containsKey(pid)) {
-                                        LOGGER.debug("CELLAR CONFIG: creating configuration pid {} on the cluster: {}", pid, Collections.list(localDictionary.keys()));
+                String oid = UUID.randomUUID().toString();
+                try {
+                    localConfigurations = configurationAdmin.listConfigurations(null);
+                    // push local configurations to the cluster
+                    for (Configuration localConfiguration : localConfigurations) {
+                        String pid = localConfiguration.getPid();
+                        // check if the pid is marked as local.
+                        if (isAllowed(group, Constants.CATEGORY, pid, EventType.OUTBOUND)) {
+                            synchronized (clusterConfigurations) {
+                                Dictionary localDictionary = localConfiguration.getProperties();
+                                localDictionary = filter(localDictionary);
+                                if (!clusterConfigurations.containsKey(pid)) {
+                                    LOGGER.debug("CELLAR CONFIG: creating configuration pid {} on the cluster: {}", pid, Collections.list(localDictionary.keys()));
+                                    // update cluster configurations
+                                    Properties props = dictionaryToProperties(localDictionary);
+                                    props.put(KARAF_CELLAR_OID, oid);
+                                    clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
+                                    // send cluster event
+                                    ClusterConfigurationEvent event = new ClusterConfigurationEvent(pid);
+                                    event.setSourceGroup(group);
+                                    event.setSourceNode(clusterManager.getNode());
+                                    event.setLocal(clusterManager.getNode());
+                                    event.setOid(oid);
+                                    eventProducer.produce(event);
+                                } else {
+                                    Dictionary clusterDictionary = clusterConfigurations.get(pid);
+                                    if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary)) {
+                                        LOGGER.debug("CELLAR CONFIG: updating configuration pid {} on the cluster", pid);
                                         // update cluster configurations
+                                        Properties props = dictionaryToProperties(localDictionary);
+                                        props.put(KARAF_CELLAR_OID, oid);
                                         clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
                                         // send cluster event
                                         ClusterConfigurationEvent event = new ClusterConfigurationEvent(pid);
                                         event.setSourceGroup(group);
-                                        event.setSourceNode(clusterManager.getNode());
                                         event.setLocal(clusterManager.getNode());
+                                        event.setSourceNode(clusterManager.getNode());
+                                        event.setOid(oid);
                                         eventProducer.produce(event);
-                                    } else {
-                                        Dictionary clusterDictionary = clusterConfigurations.get(pid);
-                                        if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary)) {
-                                            LOGGER.debug("CELLAR CONFIG: updating configuration pid {} on the cluster", pid);
-                                            // update cluster configurations
-                                            clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
-                                            // send cluster event
-                                            ClusterConfigurationEvent event = new ClusterConfigurationEvent(pid);
-                                            event.setSourceGroup(group);
-                                            event.setLocal(clusterManager.getNode());
-                                            event.setSourceNode(clusterManager.getNode());
-                                            eventProducer.produce(event);
-                                        }
                                     }
                                 }
-                            } else {
-                                LOGGER.trace("CELLAR CONFIG: configuration with PID {} is marked BLOCKED OUTBOUND for cluster group {}", pid, groupName);
                             }
+                        } else {
+                            LOGGER.trace("CELLAR CONFIG: configuration with PID {} is marked BLOCKED OUTBOUND for cluster group {}", pid, groupName);
                         }
-                        // clean configurations on the cluster not present locally
-                        for (String pid : clusterConfigurations.keySet()) {
-                            if (isAllowed(group, Constants.CATEGORY, pid, EventType.OUTBOUND)) {
-                                if (findLocalConfiguration(pid, clusterConfigurations.get(pid)) == null) {
-                                    clusterConfigurations.remove(pid);
-                                }
-                            }
-                        }
-                        getSynchronizerMap().putIfAbsent(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName, true);
-                    } catch (IOException ex) {
-                        LOGGER.error("CELLAR CONFIG: failed to read configuration (IO error)", ex);
-                    } catch (InvalidSyntaxException ex) {
-                        LOGGER.error("CELLAR CONFIG: failed to read configuration (invalid filter syntax)", ex);
                     }
+                    // clean configurations on the cluster not present locally
+                    for (String pid : clusterConfigurations.keySet()) {
+                        if (isAllowed(group, Constants.CATEGORY, pid, EventType.OUTBOUND)) {
+                            if (findLocalConfiguration(pid, clusterConfigurations.get(pid)) == null) {
+                                clusterConfigurations.remove(pid);
+                            }
+                        }
+                    }
+                    getSynchronizerMap().putIfAbsent(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName, true);
+                } catch (IOException ex) {
+                    LOGGER.error("CELLAR CONFIG: failed to read configuration (IO error)", ex);
+                } catch (InvalidSyntaxException ex) {
+                    LOGGER.error("CELLAR CONFIG: failed to read configuration (invalid filter syntax)", ex);
+                }
             } finally {
                 Thread.currentThread().setContextClassLoader(originalClassLoader);
             }

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -216,7 +216,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                     // update cluster configurations
                                     Properties props = dictionaryToProperties(localDictionary);
                                     props.put(KARAF_CELLAR_OID, oid);
-                                    clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
+                                    clusterConfigurations.put(pid, props);
                                     // send cluster event
                                     ClusterConfigurationEvent event = new ClusterConfigurationEvent(pid);
                                     event.setSourceGroup(group);
@@ -231,7 +231,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                         // update cluster configurations
                                         Properties props = dictionaryToProperties(localDictionary);
                                         props.put(KARAF_CELLAR_OID, oid);
-                                        clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
+                                        clusterConfigurations.put(pid, props);
                                         // send cluster event
                                         ClusterConfigurationEvent event = new ClusterConfigurationEvent(pid);
                                         event.setSourceGroup(group);

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -200,7 +200,6 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
             try {
                 Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
                 Configuration[] localConfigurations;
-                String oid = UUID.randomUUID().toString();
                 try {
                     localConfigurations = configurationAdmin.listConfigurations(null);
                     // push local configurations to the cluster
@@ -215,14 +214,13 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                     LOGGER.debug("CELLAR CONFIG: creating configuration pid {} on the cluster: {}", pid, Collections.list(localDictionary.keys()));
                                     // update cluster configurations
                                     Properties props = dictionaryToProperties(localDictionary);
-                                    props.put(KARAF_CELLAR_OID, oid);
                                     clusterConfigurations.put(pid, props);
                                     // send cluster event
                                     ClusterConfigurationEvent event = new ClusterConfigurationEvent(pid);
                                     event.setSourceGroup(group);
                                     event.setSourceNode(clusterManager.getNode());
                                     event.setLocal(clusterManager.getNode());
-                                    event.setOid(oid);
+                                    event.setIntegrity(hash(props));
                                     eventProducer.produce(event);
                                 } else {
                                     Dictionary clusterDictionary = clusterConfigurations.get(pid);
@@ -230,14 +228,13 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                         LOGGER.debug("CELLAR CONFIG: updating configuration pid {} on the cluster", pid);
                                         // update cluster configurations
                                         Properties props = dictionaryToProperties(localDictionary);
-                                        props.put(KARAF_CELLAR_OID, oid);
                                         clusterConfigurations.put(pid, props);
                                         // send cluster event
                                         ClusterConfigurationEvent event = new ClusterConfigurationEvent(pid);
                                         event.setSourceGroup(group);
                                         event.setLocal(clusterManager.getNode());
                                         event.setSourceNode(clusterManager.getNode());
-                                        event.setOid(oid);
+                                        event.setIntegrity(hash(props));
                                         eventProducer.produce(event);
                                     }
                                 }

--- a/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
@@ -81,8 +81,6 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
             for (Group group : groups) {
                 // check if the pid is allowed for outbound.
                 if (isAllowed(group, Constants.CATEGORY, pid, EventType.OUTBOUND)) {
-
-
                     Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + group.getName());
                     synchronized (clusterConfigurations) {
                         try {
@@ -92,7 +90,8 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                                     String filename = (String) clusterConfigurations.get(pid).get(KARAF_CELLAR_FILENAME);
                                     List<String> matchingPids = new ArrayList<String>();
                                     for (Map.Entry<String, Properties> entry : clusterConfigurations.entrySet()) {
-                                        if (filename.equals(entry.getValue().get(KARAF_CELLAR_FILENAME)) && entry.getValue().get(KARAF_CELLAR_REMOVED) == null) {
+                                        if (filename.equals(entry.getValue().get(KARAF_CELLAR_FILENAME))
+                                                && entry.getValue().get(KARAF_CELLAR_REMOVED) == null) {
                                             matchingPids.add(entry.getKey());
                                         }
                                     }
@@ -101,7 +100,8 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                                         LOGGER.debug("Marking config {} for deletion", matchingPid);
                                         Properties props = getDeletedConfigurationMarker(clusterConfigurations.get(matchingPid));
                                         props.put(KARAF_CELLAR_OID, oid);
-                                        clusterConfigurations.put(matchingPid, getDeletedConfigurationMarker(clusterConfigurations.get(matchingPid)));
+                                        clusterConfigurations.put(matchingPid,
+                                                getDeletedConfigurationMarker(clusterConfigurations.get(matchingPid)));
                                     }
                                     // send the cluster event
                                     ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);
@@ -113,29 +113,30 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                                     eventProducer.produce(clusterConfigurationEvent);
                                 }
                             } else {
-
                                 Configuration conf = configurationAdmin.getConfiguration(pid, null);
                                 Dictionary localDictionary = conf.getProperties();
                                 localDictionary = filter(localDictionary);
 
                                 Properties distributedDictionary = clusterConfigurations.get(pid);
 
-                            if (!equals(localDictionary, distributedDictionary) && canDistributeConfig(localDictionary)) {
-                                // update the configurations in the cluster group
-                                Properties props = dictionaryToProperties(localDictionary);
-                                props.put(KARAF_CELLAR_OID, oid);
-                                clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
-                                // send the cluster event
-                                ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);
-                                clusterConfigurationEvent.setSourceGroup(group);
-                                clusterConfigurationEvent.setSourceNode(clusterManager.getNode());
-                                clusterConfigurationEvent.setLocal(clusterManager.getNode());
-                                clusterConfigurationEvent.setOid(oid);
-                                eventProducer.produce(clusterConfigurationEvent);
+                                if (!equals(localDictionary, distributedDictionary) && canDistributeConfig(localDictionary)) {
+                                    // update the configurations in the cluster group
+                                    Properties props = dictionaryToProperties(localDictionary);
+                                    props.put(KARAF_CELLAR_OID, oid);
+                                    clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
+                                    // send the cluster event
+                                    ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);
+                                    clusterConfigurationEvent.setSourceGroup(group);
+                                    clusterConfigurationEvent.setSourceNode(clusterManager.getNode());
+                                    clusterConfigurationEvent.setLocal(clusterManager.getNode());
+                                    clusterConfigurationEvent.setOid(oid);
+                                    eventProducer.produce(clusterConfigurationEvent);
+                                }
                             }
+                        } catch (Exception e) {
+                            LOGGER.error("CELLAR CONFIG: failed to update configuration with PID {} in the cluster group {}", pid,
+                                    group.getName(), e);
                         }
-                    } catch (Exception e) {
-                        LOGGER.error("CELLAR CONFIG: failed to update configuration with PID {} in the cluster group {}", pid, group.getName(), e);
                     }
                 } else LOGGER.trace("CELLAR CONFIG: configuration with PID {} is marked BLOCKED OUTBOUND for cluster group {}", pid, group.getName());
             }

--- a/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
@@ -100,8 +100,7 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                                         LOGGER.debug("Marking config {} for deletion", matchingPid);
                                         Properties props = getDeletedConfigurationMarker(clusterConfigurations.get(matchingPid));
                                         props.put(KARAF_CELLAR_OID, oid);
-                                        clusterConfigurations.put(matchingPid,
-                                                getDeletedConfigurationMarker(clusterConfigurations.get(matchingPid)));
+                                        clusterConfigurations.put(matchingPid, props);
                                     }
                                     // send the cluster event
                                     ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);
@@ -123,7 +122,7 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                                     // update the configurations in the cluster group
                                     Properties props = dictionaryToProperties(localDictionary);
                                     props.put(KARAF_CELLAR_OID, oid);
-                                    clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
+                                    clusterConfigurations.put(pid, props);
                                     // send the cluster event
                                     ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);
                                     clusterConfigurationEvent.setSourceGroup(group);

--- a/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
@@ -82,9 +82,11 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                 // check if the pid is allowed for outbound.
                 if (isAllowed(group, Constants.CATEGORY, pid, EventType.OUTBOUND)) {
 
+
                     Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + group.getName());
                     synchronized (clusterConfigurations) {
                         try {
+                            String oid = UUID.randomUUID().toString();
                             if (event.getType() == ConfigurationEvent.CM_DELETED) {
                                 if (clusterConfigurations.containsKey(pid)) {
                                     String filename = (String) clusterConfigurations.get(pid).get(KARAF_CELLAR_FILENAME);
@@ -97,6 +99,8 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                                     for (String matchingPid : matchingPids) {
                                         // update the configurations in the cluster group
                                         LOGGER.debug("Marking config {} for deletion", matchingPid);
+                                        Properties props = getDeletedConfigurationMarker(clusterConfigurations.get(matchingPid));
+                                        props.put(KARAF_CELLAR_OID, oid);
                                         clusterConfigurations.put(matchingPid, getDeletedConfigurationMarker(clusterConfigurations.get(matchingPid)));
                                     }
                                     // send the cluster event
@@ -105,6 +109,7 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                                     clusterConfigurationEvent.setSourceNode(clusterManager.getNode());
                                     clusterConfigurationEvent.setSourceGroup(group);
                                     clusterConfigurationEvent.setLocal(clusterManager.getNode());
+                                    clusterConfigurationEvent.setOid(oid);
                                     eventProducer.produce(clusterConfigurationEvent);
                                 }
                             } else {
@@ -115,21 +120,22 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
 
                                 Properties distributedDictionary = clusterConfigurations.get(pid);
 
-                                if (!equals(localDictionary, distributedDictionary) && canDistributeConfig(localDictionary)) {
-                                    // update the configurations in the cluster group
-                                    LOGGER.debug("Storing configuration {} in cluster {}", pid, Collections.list(localDictionary.keys()));
-                                    clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
-                                    // send the cluster event
-                                    ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);
-                                    clusterConfigurationEvent.setSourceGroup(group);
-                                    clusterConfigurationEvent.setSourceNode(clusterManager.getNode());
-                                    clusterConfigurationEvent.setLocal(clusterManager.getNode());
-                                    eventProducer.produce(clusterConfigurationEvent);
-                                }
+                            if (!equals(localDictionary, distributedDictionary) && canDistributeConfig(localDictionary)) {
+                                // update the configurations in the cluster group
+                                Properties props = dictionaryToProperties(localDictionary);
+                                props.put(KARAF_CELLAR_OID, oid);
+                                clusterConfigurations.put(pid, dictionaryToProperties(localDictionary));
+                                // send the cluster event
+                                ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);
+                                clusterConfigurationEvent.setSourceGroup(group);
+                                clusterConfigurationEvent.setSourceNode(clusterManager.getNode());
+                                clusterConfigurationEvent.setLocal(clusterManager.getNode());
+                                clusterConfigurationEvent.setOid(oid);
+                                eventProducer.produce(clusterConfigurationEvent);
                             }
-                        } catch (Exception e) {
-                            LOGGER.error("CELLAR CONFIG: failed to update configuration with PID {} in the cluster group {}", pid, group.getName(), e);
                         }
+                    } catch (Exception e) {
+                        LOGGER.error("CELLAR CONFIG: failed to update configuration with PID {} in the cluster group {}", pid, group.getName(), e);
                     }
                 } else LOGGER.trace("CELLAR CONFIG: configuration with PID {} is marked BLOCKED OUTBOUND for cluster group {}", pid, group.getName());
             }

--- a/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
@@ -116,6 +116,7 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
 
                                 if (!equals(localDictionary, distributedDictionary) && canDistributeConfig(localDictionary)) {
                                     // update the configurations in the cluster group
+                                    LOGGER.debug("Storing configuration {} in cluster {}", pid, Collections.list(localDictionary.keys()));
                                     Properties props = dictionaryToProperties(localDictionary);
                                     clusterConfigurations.put(pid, props);
                                     // send the cluster event

--- a/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
@@ -84,7 +84,6 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                     Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + group.getName());
                     synchronized (clusterConfigurations) {
                         try {
-                            String oid = UUID.randomUUID().toString();
                             if (event.getType() == ConfigurationEvent.CM_DELETED) {
                                 if (clusterConfigurations.containsKey(pid)) {
                                     String filename = (String) clusterConfigurations.get(pid).get(KARAF_CELLAR_FILENAME);
@@ -98,9 +97,7 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                                     for (String matchingPid : matchingPids) {
                                         // update the configurations in the cluster group
                                         LOGGER.debug("Marking config {} for deletion", matchingPid);
-                                        Properties props = getDeletedConfigurationMarker(clusterConfigurations.get(matchingPid));
-                                        props.put(KARAF_CELLAR_OID, oid);
-                                        clusterConfigurations.put(matchingPid, props);
+                                        clusterConfigurations.put(matchingPid, getDeletedConfigurationMarker(clusterConfigurations.get(matchingPid)));
                                     }
                                     // send the cluster event
                                     ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);
@@ -108,7 +105,6 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                                     clusterConfigurationEvent.setSourceNode(clusterManager.getNode());
                                     clusterConfigurationEvent.setSourceGroup(group);
                                     clusterConfigurationEvent.setLocal(clusterManager.getNode());
-                                    clusterConfigurationEvent.setOid(oid);
                                     eventProducer.produce(clusterConfigurationEvent);
                                 }
                             } else {
@@ -121,14 +117,13 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
                                 if (!equals(localDictionary, distributedDictionary) && canDistributeConfig(localDictionary)) {
                                     // update the configurations in the cluster group
                                     Properties props = dictionaryToProperties(localDictionary);
-                                    props.put(KARAF_CELLAR_OID, oid);
                                     clusterConfigurations.put(pid, props);
                                     // send the cluster event
                                     ClusterConfigurationEvent clusterConfigurationEvent = new ClusterConfigurationEvent(pid);
                                     clusterConfigurationEvent.setSourceGroup(group);
                                     clusterConfigurationEvent.setSourceNode(clusterManager.getNode());
                                     clusterConfigurationEvent.setLocal(clusterManager.getNode());
-                                    clusterConfigurationEvent.setOid(oid);
+                                    clusterConfigurationEvent.setIntegrity(hash(props));
                                     eventProducer.produce(clusterConfigurationEvent);
                                 }
                             }


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/TECH-1942
https://jira.jahia.org/browse/TECH-1962

## Description

Due to a bug in configuration cluster propagation this PR propose a patch that will detect configuration replication issues and try to solve it. 
As explained in the dedicated ticket : https://jira.jahia.org/browse/BACKLOG-23021 the bug is due to a  2 phases configuration replication algorithm without transaction nor conversation management.
The patch includes a UUID in the map and in the configuration event acting as an Orchestration ID. The receiving nodes can then check if the received event is consistent with the current ReplicatedMap state. In case of inconsistency detection, a delayed retry is done 3 times before logging an error that will indicate the need for a manual resolution.
This patch is then only an inconsistency detection algorithm without any insurance of resolution. Nevertheless, the delayed retry strategy should cover most of the cases as the ReplicatedMap replication delay should not be huge.
The patch then, fix another ticket about configuration propagation failure detection and logging : TECH-1962

A ticket as been opened on the Karaf JIRA : 
https://issues.apache.org/jira/browse/KARAF-7861

The original bug is detailed in the ticket : 
https://jira.jahia.org/browse/BACKLOG-23021

A POC of another strategy is available in another branch : It is based on removing the need of a configuration event by using the Hazelcast ReplicatedMap event listener capability to trigger local synchronisation on cluster notification instead of a dedicated event. Thus removing the 2 phases will ensure a consistency over the cluster. As it is very invasive in the existing cellar codebase, it could serve as a basis for a cellar side modification.
Branche name: TECH-1942-4

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
