### PR TITLE
QA-15349: NPE on configuration replication

### DIFF
--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -81,7 +81,7 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
             synchronized (monitor) {
                 Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
                 Dictionary clusterDictionary = clusterConfigurations.get(pid);
-                LOGGER.debug("CELLAR CONFIG: Received event for configuration {}, cluster data : {}", pid, Collections.list(clusterDictionary.keys()));
+                LOGGER.debug("CELLAR CONFIG: Received event for configuration {}, cluster data : {}", pid, clusterDictionary == null ? null : Collections.list(clusterDictionary.keys()));
 
                 // Integrity check and retry if needed
                 boolean clusterConfigIntegrityCheck = integrityCheck(event.getIntegrity(), clusterDictionary);

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -81,7 +81,7 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
             synchronized (monitor) {
                 Map<String, Properties> clusterConfigurations = clusterManager.getMap(Constants.CONFIGURATION_MAP + Configurations.SEPARATOR + groupName);
                 Dictionary clusterDictionary = clusterConfigurations.get(pid);
-                LOGGER.debug("CELLAR CONFIG: Received event for configuration {}, cluster data : {}", pid, clusterDictionary == null ? null : Collections.list(clusterDictionary.keys()));
+                LOGGER.debug("CELLAR CONFIG: Received event for configuration {}, type: {}, cluster data : {}", pid, event.getType(), clusterDictionary == null ? null : Collections.list(clusterDictionary.keys()));
 
                 // Integrity check and retry if needed
                 boolean clusterConfigIntegrityCheck = integrityCheck(event.getIntegrity(), clusterDictionary);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15349

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Fix a `NullPointerException` happening during the configuration replication:
```
ERROR [EventDispatchTask] - Error while dispatching task
java.lang.NullPointerException: Cannot invoke "java.util.Dictionary.keys()" because "clusterDictionary" is null
    at org.apache.karaf.cellar.config.ConfigurationEventHandler.handle(ConfigurationEventHandler.java:84) ~[!/:?]
    at org.apache.karaf.cellar.config.ConfigurationEventHandler.handle(ConfigurationEventHandler.java:36) ~[!/:?]
    at org.apache.karaf.cellar.core.event.EventDispatchTask.run(EventDispatchTask.java:67) ~[!/:?]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
    at java.lang.Thread.run(Thread.java:833) ~[?:?] 
```

Related to https://github.com/Jahia/karaf-cellar/pull/15.