### PR TITLE
fix: improve comparison on config change

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -77,6 +77,13 @@
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Testing Dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationEventHandler.java
@@ -143,7 +143,7 @@ public class ConfigurationEventHandler extends ConfigurationSupport implements E
                                 localDictionary = new Properties();
                             }
                             localDictionary = filter(localDictionary);
-                            if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary)) {
+                            if (!areEquals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary)) {
                                 persistConfiguration(localConfiguration.getPid(), localConfiguration.getProperties(), clusterDictionary);
                                 Dictionary convertedDictionary = convertPropertiesFromCluster(clusterDictionary);
                                 if (!localConfiguration.getPid().equals(pid)) {

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSupport.java
@@ -87,34 +87,25 @@ public class ConfigurationSupport extends CellarSupport {
      * @param target the target dictionary.
      * @return true if the two dictionaries are equal, false else.
      */
-    protected boolean equals(Dictionary source, Dictionary target) {
-        if (source == null && target == null)
+    protected static boolean areEquals(Dictionary source, Dictionary target) {
+        if (Objects.equals(source, target)) {
             return true;
-
-        if (source == null || target == null)
+        }
+        if (source == null || target == null || source.size() != target.size()) {
             return false;
+        }
 
-        if (source.isEmpty() && target.isEmpty())
-            return true;
-
-        if (source.size() != target.size())
-            return false;
-
-        Enumeration sourceKeys = source.keys();
-        while (sourceKeys.hasMoreElements()) {
-            Object key = sourceKeys.nextElement();
+        Enumeration keys = source.keys();
+        while (keys.hasMoreElements()) {
+            Object key = keys.nextElement();
             if (!key.equals(org.osgi.framework.Constants.SERVICE_PID)) {
                 Object sourceValue = source.get(key);
                 Object targetValue = target.get(key);
-                if (sourceValue != null && targetValue == null)
+                if (!Objects.deepEquals(sourceValue, targetValue)) {
                     return false;
-                if (sourceValue == null && targetValue != null)
-                    return false;
-                if (!sourceValue.equals(targetValue))
-                    return false;
+                }
             }
         }
-
         return true;
     }
 

--- a/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/ConfigurationSynchronizer.java
@@ -138,7 +138,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                     localDictionary = new Properties();
 
                                 localDictionary = filter(localDictionary);
-                                if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary) && shouldReplicateConfig(clusterDictionary)) {
+                                if (!areEquals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary) && shouldReplicateConfig(clusterDictionary)) {
                                     LOGGER.debug("CELLAR CONFIG: updating configration {} on node", pid);
                                     Dictionary convertedDictionary = convertPropertiesFromCluster(clusterDictionary);
                                     persistConfiguration(localConfiguration.getPid(), localConfiguration.getProperties(), clusterDictionary);
@@ -224,7 +224,7 @@ public class ConfigurationSynchronizer extends ConfigurationSupport implements S
                                     eventProducer.produce(event);
                                 } else {
                                     Dictionary clusterDictionary = clusterConfigurations.get(pid);
-                                    if (!equals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary)) {
+                                    if (!areEquals(clusterDictionary, localDictionary) && canDistributeConfig(localDictionary)) {
                                         LOGGER.debug("CELLAR CONFIG: updating configuration pid {} on the cluster", pid);
                                         // update cluster configurations
                                         Properties props = dictionaryToProperties(localDictionary);

--- a/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
+++ b/config/src/main/java/org/apache/karaf/cellar/config/LocalConfigurationListener.java
@@ -114,7 +114,7 @@ public class LocalConfigurationListener extends ConfigurationSupport implements 
 
                                 Properties distributedDictionary = clusterConfigurations.get(pid);
 
-                                if (!equals(localDictionary, distributedDictionary) && canDistributeConfig(localDictionary)) {
+                                if (!areEquals(localDictionary, distributedDictionary) && canDistributeConfig(localDictionary)) {
                                     // update the configurations in the cluster group
                                     LOGGER.debug("Storing configuration {} in cluster {}", pid, Collections.list(localDictionary.keys()));
                                     Properties props = dictionaryToProperties(localDictionary);

--- a/config/src/test/java/org/apache/karaf/cellar/config/ConfigurationSupportTest.java
+++ b/config/src/test/java/org/apache/karaf/cellar/config/ConfigurationSupportTest.java
@@ -1,0 +1,126 @@
+package org.apache.karaf.cellar.config;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConfigurationSupportTest {
+
+    @Test
+    public void GIVEN_both_null_dictionaries_WHEN_comparing_THEN_equal() {
+        assertTrue(ConfigurationSupport.areEquals(null, null));
+    }
+
+    @Test
+    public void GIVEN_a_null_dictionary_and_a_non_null_dictionary_WHEN_comparing_THEN_different() {
+        Dictionary<String, String> source = new Hashtable<>();
+        source.put("key1", "value1");
+
+        assertFalse(ConfigurationSupport.areEquals(source, null));
+        assertFalse(ConfigurationSupport.areEquals(null, source));
+    }
+
+    @Test
+    public void GIVEN_both_empty_dictionaries_WHEN_comparing_THEN_equal() {
+        assertTrue(ConfigurationSupport.areEquals(new Hashtable<>(), new Hashtable<>()));
+    }
+
+    @Test
+    public void GIVEN_two_dictionaries_of_different_size_WHEN_comparing_THEN_different() {
+        Dictionary<String, String> source = new Hashtable<>();
+        source.put("key1", "value1");
+
+        Dictionary<String, String> target = new Hashtable<>();
+        target.put("key1", "value1");
+        target.put("key2", "value2");
+
+        assertFalse(ConfigurationSupport.areEquals(source, target));
+    }
+
+    @Test
+    public void GIVEN_two_dictionaries_of_same_size_but_different_keys_WHEN_comparing_THEN_different() {
+        Dictionary<String, String> source = new Hashtable<>();
+        source.put("key1", "value1");
+        source.put("key2", "value2");
+
+        Dictionary<String, String> target = new Hashtable<>();
+        target.put("key1", "value1");
+        target.put("differentKey", "value2");
+
+        assertFalse(ConfigurationSupport.areEquals(source, target));
+    }
+
+    @Test
+    public void GIVEN_two_dictionaries_of_same_size_same_keys_but_different_values_WHEN_comparing_THEN_different() {
+        Dictionary<String, String> source = new Hashtable<>();
+        source.put("key1", "value1");
+        source.put("key2", "value2");
+
+        Dictionary<String, String> target = new Hashtable<>();
+        target.put("key1", "value1");
+        target.put("key2", "differentValue");
+
+        assertFalse(ConfigurationSupport.areEquals(source, target));
+    }
+
+    @Test
+    public void GIVEN_two_dictionaries_of_same_size_same_keys_and_same_values_WHEN_comparing_THEN_equal() {
+        Dictionary<String, String> source = new Hashtable<>();
+        source.put("key1", "value1");
+        source.put("key2", "value2");
+
+        Dictionary<String, String> target = new Hashtable<>();
+        target.put("key1", "value1");
+        target.put("key2", "value2");
+
+        assertTrue(ConfigurationSupport.areEquals(source, target));
+    }
+
+    @Test
+    public void GIVEN_two_dictionaries_with_identical_arrays_as_values_WHEN_comparing_THEN_equal() {
+        Dictionary<String, Object> source = new Hashtable<>();
+        source.put("key", new String[]{"foo", "bar"});
+
+        Dictionary<String, Object> target = new Hashtable<>();
+        target.put("key", new String[]{"foo", "bar"});
+
+        assertTrue(ConfigurationSupport.areEquals(source, target));
+    }
+
+    @Test
+    public void GIVEN_two_dictionaries_with_identical_lists_as_values_WHEN_comparing_THEN_equal() {
+        Dictionary<String, Object> source = new Hashtable<>();
+        List<String> sourceValue = new ArrayList<>();
+        sourceValue.add("foo");
+        sourceValue.add("bar");
+        source.put("key", sourceValue);
+
+        Dictionary<String, Object> target = new Hashtable<>();
+        List<String> targetValue = new ArrayList<>();
+        targetValue.add("foo");
+        targetValue.add("bar");
+        target.put("key", targetValue);
+
+        assertTrue(ConfigurationSupport.areEquals(source, target));
+    }
+
+
+    @Test
+    public void GIVEN_two_dictionaries_identical_except_the_service_pid_WHEN_comparing_THEN_equal() {
+        Dictionary<String, String> source = new Hashtable<>();
+        source.put("key1", "value1");
+        source.put(org.osgi.framework.Constants.SERVICE_PID, "pid1");
+
+        Dictionary<String, String> target = new Hashtable<>();
+        target.put("key1", "value1");
+        target.put(org.osgi.framework.Constants.SERVICE_PID, "pid2");
+
+        assertTrue(ConfigurationSupport.areEquals(source, target));
+    }
+}


### PR DESCRIPTION
### Description
Closes https://github.com/Jahia/karaf-cellar/issues/38.
Improve the comparison of 2 dictionaries used when a configuration change event is fired, to properly handle arrays.

### Checklist

#### Tests
- [x] I've provided Unit and/or Integration Tests

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
